### PR TITLE
Add single-cell @workspace_explorer macro (fixes #3)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoWorkspaceExplorer"
 uuid = "88acd20c-1248-4a97-8a3e-4ab1c55a24a0"
 authors = ["jackn "]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 ExpressionExplorer = "21656369-7473-754a-2065-74616d696c43"
@@ -14,10 +14,10 @@ PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-julia = "^1.0"
-ExpressionExplorer = "~1.0.0"
-HTTP = "~1.10.6"
-HypertextLiteral = "~0.9.5"
-PlutoDependencyExplorer = "~1.0.3"
-PlutoUI = "~0.7.58"
-Tables = "~1.11.1"
+ExpressionExplorer = "1.0"
+HTTP = "1.10.6 - 1"
+HypertextLiteral = "0.9.5 - 0.9"
+PlutoDependencyExplorer = "1.0.3 - 1"
+PlutoUI = "0.7.58 - 0.7"
+Tables = "1.11.1 - 1"
+julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -9,17 +9,56 @@ Create the following cells:
 import PlutoWorkspaceExplorer as PWE
 ```
 ```julia
-@bind _update PWE.update_notebook()
+PWE.@workspace_explorer PlutoRunner
 ```
-```
-_update; PWE.workspace_explorer(PlutoRunner)
-```
-If you dont create the `_update` variable, then the workspace explorer will only be updated when you run the cell that defined it. The `_update` variable will change every time that you press Shift+Enter.
 
-Example view of the workspace explorer:
+That's it — a single cell shows the workspace explorer and updates it
+automatically every time you run a cell (press `Shift+Enter`).
+
 ![image](https://github.com/JackDevine/PlutoVariableExplorer.jl/assets/8610352/dc1f6cb2-2cef-47ca-b9ea-d9f1e1802fdc)
 
 https://github.com/JackDevine/PlutoVariableExplorer.jl/assets/8610352/e5a8c622-6086-44c1-a01e-e5965fccbd22
+
+## Passing options
+
+For the keyword arguments accepted by the explorer
+(`show_type`, `exclude_dependencies`, `show_pluto_modules`), use the explicit
+two-cell setup, where the second cell calls `workspace_explorer` directly:
+
+```julia
+import PlutoWorkspaceExplorer as PWE
+```
+```julia
+@bind _update PWE.update_notebook()
+```
+```julia
+_update; PWE.workspace_explorer(PlutoRunner; show_type=false,
+    exclude_dependencies=[Base, Core], show_pluto_modules=false)
+```
+
+If you dont create the `_update` variable, then the workspace explorer will only
+be updated when you run the cell that defined it. The `_update` variable will
+change every time that you press Shift+Enter.
+
+## How `@workspace_explorer` works
+
+`@workspace_explorer PlutoRunner` expands (roughly) to:
+
+```julia
+@bind _pwe_update begin
+    # a conditional self-reference: this makes the cell re-run whenever the
+    # bound value changes, while still working on the first run (before
+    # `_pwe_update` exists)
+    isdefined(@__MODULE__, :_pwe_update) ? _pwe_update : nothing
+    PlutoWorkspaceExplorer._workspace_explorer_with_trigger(PlutoRunner)
+end
+```
+
+The returned widget listens for `Shift+Enter` and sets its own bound value,
+which re-triggers the cell — a cell referencing its own bound variable is
+allowed by Pluto — re-rendering the explorer with the current workspace state.
+This bundles the trigger that previously required a separate `@bind` cell into
+the explorer itself (see [issue #3](https://github.com/JackDevine/PlutoWorkspaceExplorer.jl/issues/3)).
 
 ## License
 MIT license, see [LICENSE](LICENSE)

--- a/doc/workspace_explorer_documentation.jl
+++ b/doc/workspace_explorer_documentation.jl
@@ -22,14 +22,18 @@ end
 
 # ╔═╡ 44a6a78e-e6a3-4957-9549-84d192a11d83
 md"""
-Using the workspace explorer is a two step process. First, bind a variable to the `update_notebook` event. Then create a cell depending on the `update_notebook` event and start a workspace explorer in that cell using the `workspace_explorer(PlutoRunner)` function.
+Using the workspace explorer is a **one step** process: just call `@workspace_explorer` in a single cell. It updates automatically every time you run a cell (press `Shift+Enter`).
+
+For keyword arguments (`show_type`, `exclude_dependencies`, `show_pluto_modules`), use the two-cell setup shown below, calling `workspace_explorer(PlutoRunner; ...)` directly.
 """
 
 # ╔═╡ 236ffc2b-6a2e-4023-b9dd-6d34ea2c5d4d
-@bind _update PWE.update_notebook()
+PWE.@workspace_explorer PlutoRunner
 
 # ╔═╡ 5ccaeff5-96f2-4f3a-a4b8-a58d8192bbda
-_update; PWE.workspace_explorer(PlutoRunner)
+# Optional: the explicit two-cell setup, useful for passing keyword arguments.
+# @bind _update PWE.update_notebook()
+# _update; PWE.workspace_explorer(PlutoRunner)
 
 # ╔═╡ 9c13c584-a912-4f41-91d4-682398219895
 x = 4
@@ -77,7 +81,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 HypertextLiteral = "~0.9.5"
-PlutoWorkspaceExplorer = "~0.2.0"
+PlutoWorkspaceExplorer = "~0.3.0"
 Primes = "~0.5.6"
 Symbolics = "~5.28.0"
 """

--- a/src/PlutoWorkspaceExplorer.jl
+++ b/src/PlutoWorkspaceExplorer.jl
@@ -1,6 +1,7 @@
 module PlutoWorkspaceExplorer
 
 export workspace_explorer,
+    @workspace_explorer,
     update_notebook
 
 include("workspace_explorer.jl")

--- a/src/workspace_explorer.jl
+++ b/src/workspace_explorer.jl
@@ -42,9 +42,25 @@ th(n) = @htl("""<th>$n</th>""")
 td(n) = @htl("""<td><div><pre class="no-block">$n</pre></div></td>""")
 
 # ╔═╡ 90298b52-5ce2-4d9b-af79-427dc4f9c401
+# Wrap a value for Pluto's interactive multimedia viewer (images, arrays, tables, ...)
+# so it can be embedded inside HTML output. On Pluto <= 0.19.x this is the
+# exported `PlutoRunner.embed_display`; on Pluto 1.0.x that function was removed
+# (see AbstractPlutoDingetjes.Display.@embed), but the `EmbeddableDisplay` struct
+# that powers it still exists, so we construct it directly. This keeps the
+# explorer working on both old and new Pluto versions.
+function _embed_display(mod, x)
+	if isdefined(mod, :embed_display)
+		mod.embed_display(x)
+	elseif isdefined(mod, :EmbeddableDisplay)
+		mod.EmbeddableDisplay(x, join(rand('a':'z', 16)))
+	else
+		x
+	end
+end
+
 function render_variable_table_row(mod, ind, data...)
 	@htl("""
-	<tr>$((td(mod.embed_display(data[j][ind])) for j in eachindex(data)))</tr>
+	<tr>$((td(_embed_display(mod, data[j][ind])) for j in eachindex(data)))</tr>
 	""")
 end
 
@@ -92,6 +108,102 @@ function workspace_explorer(mod; args...)
     topology = PDE.NotebookTopology{SimpleCell}()
 
 	workspace_explorer(topology, notebook_cells, cell_exprs, mod; args...)[1]
+end
+
+# ╔═╡ 8e5b3e20-7654-4210-988d-93f5b9c81c2a
+# "Trigger" element: a hidden widget whose bound value is bumped to `null` every
+# time the user runs a cell (Shift+Enter). Used together with the
+# self-referencing `@bind` produced by `@workspace_explorer`, this makes the
+# explorer update live from a *single* cell (see GitHub issue #3).
+function _workspace_explorer_with_trigger(mod; args...)
+	@htl("""
+	<span>
+	<script>
+		// Re-evaluate this cell whenever the user runs any cell (Shift+Enter).
+		let span = currentScript.parentElement
+		let onKey = (e) => {
+			if (e.key == "Enter" && e.shiftKey) {
+				span.value = null
+				span.dispatchEvent(new CustomEvent("input"))
+				e.preventDefault()
+			}
+		}
+		document.addEventListener("keydown", onKey)
+		// The cell re-runs on every update, so we must clean up our listener to
+		// avoid stacking one keydown handler per run.
+		invalidation.then(() => document.removeEventListener("keydown", onKey))
+		span.value = null
+	</script>
+	$(workspace_explorer(mod; args...))
+	</span>
+	""")
+end
+
+# ╔═╡ fbc47ed4-2e58-4d44-b6f0-0e29d01a4b2f
+"""
+    @workspace_explorer [mod]
+
+Show the workspace explorer in a **single cell** that updates automatically every time
+you run a cell (press Shift+Enter). This bundles the "trigger" that used to
+require a separate `@bind _update PWE.update_notebook()` cell into the explorer
+itself (see [issue #3](https://github.com/JackDevine/PlutoWorkspaceExplorer.jl/issues/3)).
+
+# Example
+
+```julia
+import PlutoWorkspaceExplorer as PWE
+```
+
+```julia
+PWE.@workspace_explorer PlutoRunner
+```
+
+This single cell is equivalent to the older two-cell setup
+
+```julia
+@bind _update PWE.update_notebook()
+```
+```julia
+_update; PWE.workspace_explorer(PlutoRunner)
+```
+
+For keyword arguments (`show_type`, `exclude_dependencies`,
+`show_pluto_modules`), keep using the two-cell pattern with
+`workspace_explorer(mod; ...)`.
+
+# How it works
+
+`@workspace_explorer PlutoRunner` expands (roughly) to
+
+```julia
+@bind _pwe_update begin
+    # a conditional self-reference: this is what makes the cell re-run whenever
+    # the bound value changes, while still working on the very first run (before
+    # `_pwe_update` exists)
+    isdefined(@__MODULE__, :_pwe_update) ? _pwe_update : nothing
+    PlutoWorkspaceExplorer._workspace_explorer_with_trigger(PlutoRunner)
+end
+```
+
+The returned widget listens for Shift+Enter and sets its own bound value, which
+re-triggers the cell (a cell referencing its own bound variable is allowed by
+Pluto), re-rendering the explorer with the current workspace state.
+"""
+macro workspace_explorer(mod)
+	trigger = :_pwe_update
+	# conditional self-reference: tolerates `_pwe_update` being undefined on the
+	# first run, while still registering it as a reactive dependency of the cell.
+	self_reference = Expr(:if,
+		Expr(:call, :isdefined,
+			Expr(:macrocall, Symbol("@__MODULE__"), __source__),
+			QuoteNode(trigger)),
+		trigger,
+		:nothing)
+	call = Expr(:call,
+		GlobalRef(PlutoWorkspaceExplorer, :_workspace_explorer_with_trigger),
+		mod)
+	block = Expr(:block, self_reference, call)
+	return esc(Expr(:macrocall, Symbol("@bind"), __source__, trigger, block))
 end
 
 # ╔═╡ 7e63e520-7d60-4b6e-8668-b4efa4577948


### PR DESCRIPTION
Invoke the variable explorer from a single cell that updates automatically on every Shift+Enter, instead of requiring a separate `@bind _update` trigger cell.

`@workspace_explorer PlutoRunner` expands to a self-referencing `@bind` cell: a cell referencing its own bound variable is allowed by Pluto, so bumping the bound value (on Shift+Enter) re-runs the cell and re-renders the explorer. The first run is tolerated via `isdefined(@__MODULE__, :_pwe_update) ? _pwe_update : nothing`.

Supporting fixes needed for the explorer to work on modern Pluto:

- Widen compat bounds in Project.toml (PlutoDependencyExplorer 1.0.3-1, HTTP 1.10.6-1, etc.) so PWE coexists with Pluto 1.0.x; the old tilde-pinned bounds made `Pkg.add Pluto` unsatisfiable. Bump version to 0.3.0, julia to 1.6.

- Add _embed_display helper using PlutoRunner.embed_display on Pluto <= 0.19.x and falling back to constructing EmbeddableDisplay directly on Pluto 1.0.x, where the exported embed_display function was removed (this caused `UndefVarError: embed_display not defined in PlutoRunner`).

The two-cell pattern (update_notebook + workspace_explorer) still works for passing keyword arguments (show_type, exclude_dependencies, show_pluto_modules).